### PR TITLE
25 Add Global grid-column style to center column and background colour 

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -2,8 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+.full-bleed {
+  width: 100%;
+  grid-column: 1 / -1;
+}
+
 :root {
-  --foreground-rgb: 0,0,0;
+  --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
 }
@@ -25,5 +30,3 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
-
-

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,6 +11,6 @@ export async function getStaticProps({ locale }) {
 
 export default function Home() {
   return (
-    <div className="[background:linear-gradient(180deg,_#241b38,_#231f20)] grid grid-cols-[1fr_min(60ch,_calc(100%-64px))_1fr] gap-x-[32px] [&>*]:col-span-1 [&>*]:col-start-2 desktop:gap-x-[7.5vh] mobile:gap-x-[5vh] place-content-center"></div>
+    <div className="[background:linear-gradient(180deg,_#241b38,_#231f20)] grid grid-cols-[1fr_min(75ch,_calc(100%-64px))_1fr] gap-x-[32px] [&>*]:col-span-1 [&>*]:col-start-2 desktop:gap-x-[7.5vh] mobile:gap-x-[5vh] place-content-center"></div>
   );
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,9 +11,6 @@ export async function getStaticProps({ locale }) {
 
 export default function Home() {
   return (
-    <>
-      <p>StormHacks 2024 is coming!</p>
-    </>
-    
+    <div className="[background:linear-gradient(180deg,_#241b38,_#231f20)] grid grid-cols-[1fr_min(60ch,_calc(100%-64px))_1fr] gap-x-[32px] [&>*]:col-span-1 [&>*]:col-start-2 desktop:gap-x-[7.5vh] mobile:gap-x-[5vh] place-content-center"></div>
   );
 }


### PR DESCRIPTION
## Describe your changes
1. Used CSS grid in the top-most element of the homepage to place content in a middle column. 
2. Added background gradient to the top-most element of the homepage. 


## Issue ticket number and link
https://github.com/sfusurge/stormhacks_website/issues/25

## Testing Steps
1. checkout to `25-add-full-bleed`
2. Add some elements to the home page and make sure that they appear in the center column at all screen sizes. E.g Add a <p></p> element with a long line of dummy text
3. Run the development server, and ensure that the screen and elements are responsive to changes